### PR TITLE
Updates for pyglet 1.4

### DIFF
--- a/arrayimage.py
+++ b/arrayimage.py
@@ -172,7 +172,7 @@ class ArrayInterfaceImage(ImageData):
         '''Force an update of the texture data.
         '''
 
-        texture = self.texture
+        texture = self.get_texture()
         internalformat = None
         self.blit_to_texture(
             texture.target, texture.level, 0, 0, 0, internalformat )

--- a/image_data_pipeline.py
+++ b/image_data_pipeline.py
@@ -662,12 +662,6 @@ class Display:
         ):
         import warnings
         import pyglet
-        pyglet_version = getattr(pyglet, 'version', '0.0.0')
-        if version.parse(pyglet_version) < version.parse('1.3'):
-            info(f'Old version of pyglet (v{pyglet_version}) was detected.')
-            info(f'This version has not been tested' +
-                   ' and is not guaranteed to work.')
-            info(f'To get rid of this message, please upgrade pyglet >= v1.3.')
         self.pyg = pyglet
         try:
             with warnings.catch_warnings():

--- a/image_data_pipeline.py
+++ b/image_data_pipeline.py
@@ -662,6 +662,12 @@ class Display:
         ):
         import warnings
         import pyglet
+        pyglet_version = getattr(pyglet, 'version', '0.0.0')
+        if version.parse(pyglet_version) < version.parse('1.3'):
+            info(f'Old version of pyglet (v{pyglet_version}) was detected.')
+            info(f'This version has not been tested' +
+                   ' and is not guaranteed to work.')
+            info(f'To get rid of this message, please upgrade pyglet >= v1.3.')
         self.pyg = pyglet
         try:
             with warnings.catch_warnings():

--- a/image_data_pipeline.py
+++ b/image_data_pipeline.py
@@ -1036,8 +1036,7 @@ class Display:
         return None
 
     def _get_screen_dimensions(self):
-        plat = self.pyg.window.Platform()
-        disp = plat.get_default_display()
+        disp = self.pyg.canvas.get_display()
         screen = disp.get_default_screen()
         return screen.width, screen.height
 


### PR DESCRIPTION
Minor tweaks to idp and array_image to update for pyglet 1.4 ([Pyglet Release Notes](https://github.com/pyglet/pyglet/blob/8d81fb4ad65e14e0346a3cf5213bdadc6416760c/RELEASE_NOTES#L83))

The release notes state that these methods/attributes have long been deprecated, so it is unlikely that these changes will break any code that is currently running, unless it is using a very old version of pyglet. I tested versions 1.3 and 1.4 on Windows and OSX machines, but I added a warning if older an version of pyglet is detected. 

I checked the rest of the idp array image code for any of the other listed changes and did not find anything else that needs to change. 

