### PR TITLE
updated join to accept the same args/kwargs

### DIFF
--- a/proxy_objects.py
+++ b/proxy_objects.py
@@ -663,8 +663,8 @@ def _my_excepthook(t, v, tb):
 sys.excepthook = _my_excepthook
 
 class _RaiseOnJoinThread(threading.Thread):
-    def join(self, *args, **kwargs):
-        super().join(*args, **kwargs)
+    def join(self, timeout=None):
+        super().join(timeout=timeout)
         if hasattr(self, 'exc_value'):
             raise self.exc_value
 

--- a/proxy_objects.py
+++ b/proxy_objects.py
@@ -663,8 +663,8 @@ def _my_excepthook(t, v, tb):
 sys.excepthook = _my_excepthook
 
 class _RaiseOnJoinThread(threading.Thread):
-    def join(self):
-        super().join()
+    def join(self, *args, **kwargs):
+        super().join(*args, **kwargs)
         if hasattr(self, 'exc_value'):
             raise self.exc_value
 


### PR DESCRIPTION
I found that I wanted to use the `timeout` argument when calling the `join` method of a `_RaiseOnJoinThread`. This change should allow the subclassed `join` method to accept the same args/kwargs as `threading.Thread.join`