### PR TITLE
locate SC2_Cam.dll in the directory with pco.py

### DIFF
--- a/pco.py
+++ b/pco.py
@@ -1,5 +1,6 @@
 import time
 import ctypes as C
+import os
 import numpy as np
 
 class Camera:
@@ -903,7 +904,9 @@ class DMAError(Exception):
 
 # DLL management
 try:
-    dll = C.oledll.LoadLibrary("./SC2_Cam.dll")
+    dll = C.oledll.LoadLibrary(
+        os.path.join(os.path.dirname(__file__), 'SC2_Cam.dll')
+    )
 except WindowsError:
     print("Failed to load SC2_Cam.dll")
     print("You need this to run pco.py")

--- a/pco.py
+++ b/pco.py
@@ -904,9 +904,10 @@ class DMAError(Exception):
 
 # DLL management
 try:
-    dll = C.oledll.LoadLibrary(
-        os.path.join(os.path.dirname(__file__), 'SC2_Cam.dll')
-    )
+    dll_path = os.path.join(
+        os.path.dirname(os.path.abspath(__file__)),
+        'SC2_Cam.dll')
+    dll = C.oledll.LoadLibrary(dll_path)
 except WindowsError:
     print("Failed to load SC2_Cam.dll")
     print("You need this to run pco.py")


### PR DESCRIPTION
The previous behavior forced SC2_Cam.dll to be located in the current working directory. This was annoying and forced an organization that might not work with all projects. 

A while ago (prior to c0c33260ee6ba08df50745ce0d9bf80fad256260), SC2_Cam.dll just had to be located on the system PATH, however new versions of python/ctypes changed the way they located DLLs and forced a more specific path to be specified.  

This change allows SC2_Cam.dll to be located in the same folder as pco.py, independent of the current working directory. As long as pco.py is on the PATH/PYTHONPATH, it should be able build the correct path to load the DLL. I think this is closer to the original behavior.