### PR TITLE
Use multiprocessing.shared_memory.SharedMemory

### DIFF
--- a/concurrency_tools.py
+++ b/concurrency_tools.py
@@ -1150,6 +1150,7 @@ class TestSharedNDArray(MyTestClass):
         except FileNotFoundError:
             pass # we expected this error
         else:
+            import os
             if os.name == 'nt':
                 # This is allowed on Windows. Windows will keep memory
                 # allocated until all references have been lost from every

--- a/concurrency_tools.py
+++ b/concurrency_tools.py
@@ -1049,7 +1049,7 @@ class _Tests():
         assert _view_by_slice.sum() == view_by_slice.sum()
 
     def test_accessing_unlinked_memory(self):
-        import pickle
+        import pickle, os
         original_dimensions = (3, 3, 3, 256, 256)
         a = SharedNDArray(shape=original_dimensions, dtype='uint8')
         _a = pickle.dumps(a)
@@ -1071,7 +1071,10 @@ class _Tests():
         except FileNotFoundError:
             pass # we expected this error
         else:
-            raise AssertionError('Did not get the error we expected')
+            if os.name != 'nt':
+                raise AssertionError('Did not get the error we expected')
+            else:
+                pass # Windows has different behavior
 
     def test_sending_arrays(self):
         p = ObjectInSubprocess(_Tests.TestClass)
@@ -1097,7 +1100,7 @@ class _Tests():
         assert _a.strides != a.strides
 
         _a = p.sum(a)
-        assert isinstance(_a, np.uint64)
+        assert np.isscalar(_a), type(_a)
 
     def test_indexing_views_of_views(self):
         import pickle

--- a/proxied_napari.py
+++ b/proxied_napari.py
@@ -8,27 +8,21 @@ import traceback
 import napari
 from qtpy.QtCore import QTimer
 # Our stuff
-from proxy_objects import (
-    ProxyManager, _dummy_function, _reconnect_shared_arrays, _SharedNumpyArray)
+from concurrency_tools import (
+    _dummy_function, SharedNumpyArray, ObjectInSubprocess)
 
-def display(proxy_manager=None, display_type=None):
+def display(display_type=None):
     """Creates a simplified non-blocking napari viewer in a subprocess.
 
     If you don't know what you're doing, this is probably the only thing
     you should import from this module.
 
-    If you're using a ProxyManager, pass it as `proxy_manager` so the
-    display can use the same shared memory.
-
     If you're using a custom _NapariDisplay, pass it as `display_type`.
     """
-    if proxy_manager is None:
-        proxy_manager = ProxyManager()
     if display_type is None:
         display_type = _NapariDisplay
-    display = proxy_manager.proxy_object(display_type,
-                                         custom_loop=_napari_child_loop,
-                                         close_method_name='close')
+    display = ObjectInSubprocess(display_type, custom_loop=_napari_child_loop,
+                                 close_method_name='close')
     return display
 
 class _NapariDisplay:
@@ -57,15 +51,13 @@ class _NapariDisplay:
 # this can probably be done by creating your own modified version of the
 # _NapariDisplay  class above.
 
-def _napari_child_loop(child_pipe, shared_arrays,
-                       initializer, initargs, initkwargs,
+def _napari_child_loop(child_pipe, initializer, initargs, initkwargs,
                        close_method_name, closeargs, closekwargs):
     """Teach Qt's event loop how to act like a ProxyObject's child process."""
 
     # If any of the initargs are _SharedNumpyArrays, we have to show them where
     # to find shared memory:
-    initargs, initkwargs = _reconnect_shared_arrays(
-        initargs, initkwargs, shared_arrays)
+
     closeargs = tuple() if closeargs is None else closeargs
     closekwargs = dict() if closekwargs is None else closekwargs
     state = { # Mutable, to store the state of the child object.
@@ -128,15 +120,11 @@ def _napari_child_loop(child_pipe, shared_arrays,
                         close_method(*closeargs, **closekwargs)
                     return
                 method_name, args, kwargs = cmd
-                args, kwargs = _reconnect_shared_arrays(
-                    args, kwargs, shared_arrays)
                 try:
                     with redirect_stdout(printed_output):
                         result = getattr(obj, method_name)(*args, **kwargs)
                     if callable(result):
                         result = _dummy_function # Cheaper than a real callable
-                    if isinstance(result, _SharedNumpyArray):
-                        result = result._disconnect()
                     child_pipe.send((result, printed_output.getvalue()))
                 except Exception as e:
                     e.child_traceback_string = traceback.format_exc()
@@ -159,25 +147,22 @@ class _Microscope:
     def __init__(self):
         import queue
         import time
-        self.pm = ProxyManager(shared_memory_sizes=(1*2048*2060*2,))
         self.data_buffers = [
-            self.pm.shared_numpy_array(which_mp_array=0,
-                                       shape=(1, 2048, 2060),
-                                       dtype='uint16')
+            SharedNumpyArray(shape=(1, 2048, 2060), dtype='uint16')
             for i in range(2)]
         self.data_buffer_queue = queue.Queue()
         for i in range(len(self.data_buffers)):
             self.data_buffer_queue.put(i)
         print("Displaying", self.data_buffers[0].shape,
               self.data_buffers[0].dtype, 'images.')
-        self.camera = self.pm.proxy_object(_Camera)
-        self.display = display(proxy_manager=self.pm)
+        self.camera = ObjectInSubprocess(_Camera)
+        self.display = display()
         self.num_frames = 0
         self.initial_time = time.perf_counter()
 
     def snap(self):
         import time
-        from proxy_objects import launch_custody_thread
+        from concurrency_tools import CustodyThread
         def snap_task(custody):
             custody.switch_from(None, to=self.camera)
             which_buffer = self.data_buffer_queue.get()
@@ -193,8 +178,8 @@ class _Microscope:
                 print("%0.2f average FPS"%(self.num_frames / time_elapsed))
                 self.num_frames = 0
                 self.initial_time = time.perf_counter()
-        th = launch_custody_thread(snap_task, first_resource=self.camera)
-        return th
+        th = CustodyThread(first_resource=self.camera, target=snap_task)
+        return th.start()
 
 class _Camera:
     def record(self, out):
@@ -208,12 +193,8 @@ if __name__ == '__main__':
     import threading
     print("Launching a ton of 'snap' threads...")
     for i in range(50):
-        try:
-            th = scope.snap()
-            snap_threads.append(th)
-        except RuntimeError:
-            print('running threads: ', threading.active_count())
-            break
+        th = scope.snap()
+        snap_threads.append(th)
     print(len(snap_threads), "'snap' threads launched.")
     for th in snap_threads:
         th.join()
@@ -225,8 +206,8 @@ if __name__ == '__main__':
     # If you want to kill the child process before the end of the script,
     # you have to do something like this:
 
-    import proxy_objects
-    proxy_objects._close(scope.display)
+    import concurrency_tools
+    concurrency_tools._close(scope.display)
 
     # We'll look into a way to make this a little easier to do. In theory,
     # the child process should close when the proxy_object is garbage

--- a/proxied_napari.py
+++ b/proxied_napari.py
@@ -203,26 +203,13 @@ if __name__ == '__main__':
     # This will just close the viewer, not the child process.
     scope.display.close()
 
-    # If you want to kill the child process before the end of the script,
-    # you have to do something like this:
+    # If you want to stop the child process before the end of the script,
+    # all you have to do is remove all references to the object:
+    con = getattr(scope.display, '_')
+    scope.display = None # or del scope.display
+    assert not con.child_process.is_alive(), 'Napari process should be dead!'
 
-    import concurrency_tools
-    concurrency_tools._close(scope.display)
 
-    # We'll look into a way to make this a little easier to do. In theory,
-    # the child process should close when the proxy_object is garbage
-    # collected, however this isn't happening when we expect it to. Something
-    # for us to look into...
 
-    input('Hit enter to run off the end of the script...')
-
-    # Note -- calling methods of a closed proxy object will result in an
-    # OSError.
-    try:
-        scope.display.close()
-    except OSError:
-        pass # This is the exception we expected!
-    else:
-        raise AssertionError('We did not get the error we expected')
 
 

--- a/proxy_objects.py
+++ b/proxy_objects.py
@@ -561,6 +561,7 @@ class _SharedNumpyArray(np.ndarray):
         if shared_memory_name is None:
             dtype = np.dtype(dtype)
             requested_bytes = np.prod(shape, dtype='uint64') * dtype.itemsize
+            requested_bytes = int(requested_bytes) # SharedMemory need int on PC
             shm = shared_memory.SharedMemory(create=True, size=requested_bytes)
             atexit.register(lambda: _SharedNumpyArray._unlink(shm))
         else:


### PR DESCRIPTION
This should:
- Improve speed of initialization.
- Allow allocating shared memory after you've created the ObjectsInSubpresses
- Fix an issue when passing views of views of numpy arrays
- Allow passing objects that contain `_SharedNumpyArrays` and have them efficiently passed by reference. 
